### PR TITLE
feat: add optional KMS encryption support

### DIFF
--- a/encryption.tf
+++ b/encryption.tf
@@ -3,7 +3,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = var.kms_key_arn != null ? "aws:kms" : "AES256"
+      kms_master_key_id = var.kms_key_arn
     }
+    bucket_key_enabled = var.kms_key_arn != null
   }
 }

--- a/test_data/test_kms/.gitignore
+++ b/test_data/test_kms/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfvars
+terraform.tf

--- a/test_data/test_kms/datasources.tf
+++ b/test_data/test_kms/datasources.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/test_data/test_kms/main.tf
+++ b/test_data/test_kms/main.tf
@@ -1,0 +1,18 @@
+resource "aws_kms_key" "test" {
+  description             = "Test KMS key for S3 bucket encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+
+module "bucket" {
+  source        = "../../"
+  bucket_prefix = "test-kms-"
+  force_destroy = true
+  kms_key_arn   = aws_kms_key.test.arn
+}
+
+module "bucket_default" {
+  source        = "../../"
+  bucket_prefix = "test-default-enc-"
+  force_destroy = true
+}

--- a/test_data/test_kms/outputs.tf
+++ b/test_data/test_kms/outputs.tf
@@ -1,0 +1,19 @@
+output "kms_bucket_name" {
+  value = module.bucket.bucket_name
+}
+
+output "kms_bucket_arn" {
+  value = module.bucket.bucket_arn
+}
+
+output "default_bucket_name" {
+  value = module.bucket_default.bucket_name
+}
+
+output "default_bucket_arn" {
+  value = module.bucket_default.bucket_arn
+}
+
+output "kms_key_arn" {
+  value = aws_kms_key.test.arn
+}

--- a/test_data/test_kms/providers.tf
+++ b/test_data/test_kms/providers.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  dynamic "assume_role" {
+    for_each = var.role_arn != null ? [1] : []
+    content {
+      role_arn = var.role_arn
+    }
+  }
+  region = var.region
+  default_tags {
+    tags = {
+      "created_by" : "infrahouse/terraform-aws-s3-bucket"
+    }
+
+  }
+}

--- a/test_data/test_kms/variables.tf
+++ b/test_data/test_kms/variables.tf
@@ -1,0 +1,5 @@
+variable "role_arn" {
+  default = null
+}
+variable "region" {
+}

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -3,6 +3,7 @@ from os import path as osp, remove
 from shutil import rmtree
 from textwrap import dedent
 
+import boto3
 import pytest
 from pytest_infrahouse import terraform_apply
 
@@ -77,3 +78,119 @@ def test_module(
         json_output=True,
     ) as tf_output:
         LOG.info(json.dumps(tf_output, indent=4))
+
+
+def _build_s3_client(test_role_arn: str, aws_region: str) -> boto3.client:
+    """
+    Build an S3 client, assuming the test role if provided.
+
+    :param test_role_arn: ARN of the IAM role to assume, or None for default credentials
+    :param aws_region: AWS region for the client
+    :return: boto3 S3 client
+    """
+    if test_role_arn:
+        sts = boto3.client("sts", region_name=aws_region)
+        creds = sts.assume_role(
+            RoleArn=test_role_arn,
+            RoleSessionName="test-s3-bucket",
+        )["Credentials"]
+        return boto3.client(
+            "s3",
+            region_name=aws_region,
+            aws_access_key_id=creds["AccessKeyId"],
+            aws_secret_access_key=creds["SecretAccessKey"],
+            aws_session_token=creds["SessionToken"],
+        )
+    return boto3.client("s3", region_name=aws_region)
+
+
+@pytest.mark.parametrize(
+    "aws_provider_version", ["~> 5.31", "~> 6.0"], ids=["aws-5", "aws-6"]
+)
+def test_kms_encryption(
+    test_role_arn,
+    keep_after,
+    aws_region,
+    aws_provider_version,
+):
+    """Test that KMS encryption is correctly configured when kms_key_arn is provided."""
+    terraform_dir = osp.join(TERRAFORM_ROOT_DIR, "test_kms")
+    state_files = [
+        osp.join(terraform_dir, ".terraform"),
+        osp.join(terraform_dir, ".terraform.lock.hcl"),
+    ]
+
+    for state_file in state_files:
+        try:
+            if osp.isdir(state_file):
+                rmtree(state_file)
+            elif osp.isfile(state_file):
+                remove(state_file)
+        except FileNotFoundError:
+            pass
+
+    with open(osp.join(terraform_dir, "terraform.tfvars"), "w") as fp:
+        fp.write(
+            dedent(
+                f"""
+                region          = "{aws_region}"
+                """
+            )
+        )
+        if test_role_arn:
+            fp.write(
+                dedent(
+                    f"""
+                    role_arn      = "{test_role_arn}"
+                    """
+                )
+            )
+
+    with open(osp.join(terraform_dir, "terraform.tf"), "w") as fp:
+        fp.write(
+            dedent(
+                f"""
+                terraform {{
+                  required_providers {{
+                    aws = {{
+                      source  = "hashicorp/aws"
+                      version = "{aws_provider_version}"
+                    }}
+                  }}
+                }}
+                """
+            )
+        )
+    with terraform_apply(
+        terraform_dir,
+        destroy_after=not keep_after,
+        json_output=True,
+    ) as tf_output:
+        LOG.info(json.dumps(tf_output, indent=4))
+        s3_client = _build_s3_client(test_role_arn, aws_region)
+
+        # Verify KMS-encrypted bucket uses SSE-KMS with bucket key
+        kms_bucket = tf_output["kms_bucket_name"]["value"]
+        kms_enc = s3_client.get_bucket_encryption(Bucket=kms_bucket)
+        kms_rules = kms_enc["ServerSideEncryptionConfiguration"]["Rules"]
+        assert len(kms_rules) == 1
+        kms_default = kms_rules[0]["ApplyServerSideEncryptionByDefault"]
+        assert kms_default["SSEAlgorithm"] == "aws:kms", (
+            f"Expected aws:kms, got {kms_default['SSEAlgorithm']}"
+        )
+        assert kms_default["KMSMasterKeyID"] == tf_output["kms_key_arn"]["value"], (
+            "KMS key ARN mismatch"
+        )
+        assert kms_rules[0]["BucketKeyEnabled"] is True, (
+            "Bucket key should be enabled for SSE-KMS"
+        )
+
+        # Verify default bucket still uses AES256
+        default_bucket = tf_output["default_bucket_name"]["value"]
+        default_enc = s3_client.get_bucket_encryption(Bucket=default_bucket)
+        default_rules = default_enc["ServerSideEncryptionConfiguration"]["Rules"]
+        assert len(default_rules) == 1
+        default_algo = default_rules[0]["ApplyServerSideEncryptionByDefault"]
+        assert default_algo["SSEAlgorithm"] == "AES256", (
+            f"Expected AES256, got {default_algo['SSEAlgorithm']}"
+        )

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "force_destroy" {
   default     = false
 }
 
+variable "kms_key_arn" {
+  description = "ARN of a KMS key for SSE-KMS encryption. When set, the bucket uses aws:kms with S3 Bucket Keys enabled. When null (default), the bucket uses AES256 (SSE-S3)."
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "Tags to apply on S3 bucket"
   type        = map(string)


### PR DESCRIPTION
## Summary

- Add `kms_key_arn` variable to enable SSE-KMS encryption with S3 Bucket Keys
- When `kms_key_arn` is null (default), the bucket uses AES256 (SSE-S3) — no breaking change
- When set, the bucket uses `aws:kms` with `bucket_key_enabled = true` to reduce KMS API costs

## Changes

| File | Change |
|------|--------|
| `variables.tf` | Add `kms_key_arn` variable (string, default null) |
| `encryption.tf` | Conditional SSE-KMS vs AES256 based on `kms_key_arn` |
| `test_data/test_kms/` | Test infrastructure with KMS key + two buckets (KMS and default) |
| `tests/test_module.py` | `test_kms_encryption` with boto3 assertions verifying actual bucket config |

## Test plan

- [x] `terraform fmt -recursive` passes
- [ ] `test_kms_encryption` verifies SSE-KMS bucket has correct algorithm, key ARN, and bucket key enabled
- [ ] `test_kms_encryption` verifies default bucket still uses AES256
- [ ] Tests parameterized for AWS provider ~> 5.31 and ~> 6.0

## Usage

```hcl
module "encrypted_bucket" {
  source      = "infrahouse/s3-bucket/aws"
  bucket_name = "my-secure-bucket"
  kms_key_arn = aws_kms_key.my_key.arn
}
```