### PR TITLE
security: deny KMS-encrypted uploads to prevent silent replication gaps

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,2 @@
+- [Skip low-value tests](feedback_no_unnecessary_tests.md) — don't test platform behavior, only module logic
+- [README provider versions](feedback_readme_provider_version.md) — reusable modules show constraint ranges, not pinned versions

--- a/.claude/memory/feedback_no_unnecessary_tests.md
+++ b/.claude/memory/feedback_no_unnecessary_tests.md
@@ -1,0 +1,11 @@
+---
+name: Skip low-value tests
+description: Don't add tests that just verify AWS/Terraform behavior rather than module logic
+type: feedback
+---
+
+Skip tests that verify platform behavior rather than module logic. E.g., if a policy denies two values via the same StringEquals condition, testing one is enough — testing both just verifies AWS evaluates lists correctly.
+
+**Why:** Tests create real AWS infrastructure and cost time/money. Each test should validate module behavior, not platform mechanics.
+
+**How to apply:** When suggesting tests, ask whether the test validates module logic or just platform behavior. Skip the latter.

--- a/.claude/memory/feedback_readme_provider_version.md
+++ b/.claude/memory/feedback_readme_provider_version.md
@@ -1,0 +1,11 @@
+---
+name: README provider version is a range for reusable modules
+description: Don't replace provider version ranges with pinned versions in README - reusable modules show constraints, not resolved versions
+type: feedback
+---
+
+For reusable Terraform modules (not root modules), the provider version in README should show the constraint range (e.g., `>= 6.0, < 7.0`), not a resolved/pinned version (e.g., `6.44.0`). terraform-docs generates this correctly when there's no lock file.
+
+**Why:** A reusable module declares version constraints, not exact versions. The lock file pins versions only for root modules. Showing a pinned version in a child module README is misleading.
+
+**How to apply:** Never manually edit terraform-docs generated sections in README. Don't run `terraform init` in reusable module directories as it creates state that affects terraform-docs output.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ No modules.
 | [aws_s3_bucket_versioning.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.deny_kms_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.enforce_ssl_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.replica_ssl_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.replication_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/data-sources.tf
+++ b/data-sources.tf
@@ -5,8 +5,35 @@ data "aws_iam_policy_document" "bucket_policy" {
     [
       var.bucket_policy,
       data.aws_iam_policy_document.enforce_ssl_policy.json,
+      data.aws_iam_policy_document.deny_kms_encryption.json,
     ]
   )
+}
+
+data "aws_iam_policy_document" "deny_kms_encryption" {
+  statement {
+    sid    = "DenyKMSEncryptedUploads"
+    effect = "Deny"
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.this.arn}/*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = ["aws:kms", "aws:kms:dsse"]
+    }
+  }
 }
 
 data "aws_iam_policy_document" "enforce_ssl_policy" {

--- a/data-sources.tf
+++ b/data-sources.tf
@@ -10,6 +10,8 @@ data "aws_iam_policy_document" "bucket_policy" {
   )
 }
 
+# KMS-encrypted objects silently fail to replicate without additional KMS key
+# configuration in the replica region. Deny KMS uploads to ensure AES256 only.
 data "aws_iam_policy_document" "deny_kms_encryption" {
   statement {
     sid    = "DenyKMSEncryptedUploads"

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -4,6 +4,7 @@ from os import path as osp, remove
 from shutil import rmtree
 from textwrap import dedent
 
+import botocore.exceptions
 import pytest
 from infrahouse_core.timeout import timeout
 from pytest_infrahouse import terraform_apply
@@ -102,3 +103,14 @@ def test_module(
                     break
                 except s3_replica.exceptions.NoSuchKey:
                     LOG.info("Object not yet replicated, retrying...")
+
+        # Verify KMS-encrypted uploads are denied
+        with pytest.raises(botocore.exceptions.ClientError) as exc_info:
+            s3_source.put_object(
+                Bucket=source_bucket,
+                Key="test-kms-denied.txt",
+                Body=b"should be denied",
+                ServerSideEncryption="aws:kms",
+            )
+        assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+        LOG.info("KMS upload correctly denied")


### PR DESCRIPTION
## Summary

- Adds a bucket policy statement that denies `s3:PutObject` with `aws:kms` or `aws:kms:dsse` server-side encryption
- S3 replication silently skips KMS-encrypted objects unless explicitly configured with `sse_kms_encrypted_objects` and a replica KMS key. Since the module enforces AES256, allowing KMS uploads creates a gap where objects appear to be stored but are never replicated
- Extends the test to verify KMS uploads are rejected with `AccessDenied`

## Test plan

- [ ] Existing replication test passes (AES256 object replicates successfully)
- [ ] New assertion validates KMS upload is denied with `AccessDenied`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)