### PR TITLE
feat: add per-test Vanta exemption tags for compliance automation

### DIFF
--- a/.claude/plans/vanta-exemptions.md
+++ b/.claude/plans/vanta-exemptions.md
@@ -1,0 +1,203 @@
+# Plan: Vanta per-test exemption tags
+
+**Linear ticket:** INF-1539
+**Module:** terraform-aws-s3-bucket
+**Current version:** 0.4.1
+
+## Context
+
+Vanta test `aws-s3-cross-region-replication-enabled` is failing on 244 S3 buckets
+across TinyFish's AWS org. ~143 of those buckets should be exempt from this specific
+test (operational logs, lambda artifacts, GHA runner artifacts, athena query spool,
+http-redirect buckets, package buckets, etc.) but must remain in scope for every
+other S3 test (encryption, public access, versioning).
+
+Vanta's tag-based scoping (`VantaNonProd`, `VantaNoAlert`) suppresses all tests on a
+resource -- too blunt. The per-test deactivation API
+(`POST /v1/tests/{testId}/entities/{entityId}/deactivate`) is the correct primitive.
+
+A reconciler Lambda in `terraform-aws-org-governance` will scan Vanta for failing
+entities, look up the corresponding AWS bucket, check for exemption tags, and call
+the Vanta API to deactivate/reactivate accordingly. This module's job is to stamp
+the right tags so the reconciler can find them.
+
+## Changes
+
+### 1. New variable: `vanta_exemptions`
+
+```hcl
+variable "vanta_exemptions" {
+  description = <<-EOT
+    Map of Vanta test slugs to exemption reasons. Each entry causes a
+    tag `vanta-exempt:<slug> = <reason>` to be applied to the bucket.
+    The reconciler Lambda in terraform-aws-org-governance reads these
+    tags and calls the Vanta per-test deactivation API.
+
+    Keys must be known Vanta test slugs (validated at plan time).
+    Values must conform to AWS tag value constraints (<=256 chars,
+    allowed character set).
+  EOT
+  type    = map(string)
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for slug, reason in var.vanta_exemptions :
+      contains(local.known_vanta_test_slugs, slug)
+    ])
+    error_message = <<-EOT
+      Unknown Vanta test slug. Known slugs:
+        - aws-s3-cross-region-replication-enabled
+    EOT
+  }
+
+  validation {
+    condition = alltrue([
+      for slug, reason in var.vanta_exemptions :
+      length(reason) > 0 && length(reason) <= 256
+    ])
+    error_message = "Exemption reason must be between 1 and 256 characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for slug, reason in var.vanta_exemptions :
+      can(regex("^[\\w\\s+=.,:/@-]*$", reason))
+    ])
+    error_message = <<-EOT
+      Exemption reason may only contain letters, digits, spaces,
+      and the characters + - = . _ : / @
+    EOT
+  }
+}
+```
+
+File: `variables.tf`
+
+### 2. New local: `known_vanta_test_slugs`
+
+```hcl
+locals {
+  known_vanta_test_slugs = [
+    "aws-s3-cross-region-replication-enabled",
+  ]
+}
+```
+
+File: `locals.tf` (append to existing locals block)
+
+### 3. New local: `vanta_exempt_tags`
+
+Transforms the `vanta_exemptions` map into AWS tags with the `vanta-exempt:` prefix:
+
+```hcl
+locals {
+  vanta_exempt_tags = {
+    for slug, reason in var.vanta_exemptions :
+    "vanta-exempt:${slug}" => reason
+  }
+}
+```
+
+File: `locals.tf`
+
+### 4. Apply exemption tags to the primary bucket
+
+Update `aws_s3_bucket.this` to merge in the exemption tags:
+
+```hcl
+resource "aws_s3_bucket" "this" {
+  bucket        = var.bucket_name
+  bucket_prefix = var.bucket_prefix
+  force_destroy = var.force_destroy
+  tags = merge(
+    local.default_module_tags,
+    var.tags,
+    local.vanta_exempt_tags,
+    {
+      "module_version" : local.module_version
+    }
+  )
+}
+```
+
+File: `main.tf`
+
+### 5. Auto-exempt the replica bucket from CRR test
+
+The replica bucket is a replication destination -- testing it for CRR is
+nonsensical. The module hardcodes this exemption:
+
+```hcl
+resource "aws_s3_bucket" "replica" {
+  count         = var.replication_region != null ? 1 : 0
+  bucket        = var.bucket_name != null ? "${var.bucket_name}-replica" : null
+  bucket_prefix = var.bucket_prefix != null ? "${var.bucket_prefix}-replica" : null
+  force_destroy = var.force_destroy
+  region        = var.replication_region
+
+  tags = merge(
+    local.default_module_tags,
+    var.tags,
+    {
+      "vanta-exempt:aws-s3-cross-region-replication-enabled" = "Replica destination bucket - CRR test applies to source not target"
+    },
+  )
+
+  # ... existing lifecycle block unchanged ...
+}
+```
+
+File: `replication.tf`
+
+## Files changed
+
+| File            | Change                                                    |
+|-----------------|-----------------------------------------------------------|
+| `variables.tf`  | Add `vanta_exemptions` variable with validation           |
+| `locals.tf`     | Add `known_vanta_test_slugs` and `vanta_exempt_tags`      |
+| `main.tf`       | Merge `local.vanta_exempt_tags` into primary bucket tags  |
+| `replication.tf` | Add hardcoded CRR exemption tag on replica bucket        |
+
+## Consumer module usage
+
+Consumer modules pass exemptions with domain-specific reasons:
+
+```hcl
+# In terraform-aws-lambda-monitored (or similar)
+module "lambda_bucket" {
+  source = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
+
+  bucket_prefix = "my-lambda-artifacts"
+
+  vanta_exemptions = {
+    "aws-s3-cross-region-replication-enabled" = "Lambda artifact bucket - ephemeral build output, no DR value"
+  }
+}
+```
+
+Modules that create buckets requiring CRR (tfstate, backups, production data)
+simply omit `vanta_exemptions` -- those buckets remain in scope and must have
+replication configured.
+
+## What this does NOT do
+
+- Does not call the Vanta API. Tag presence is the contract; the reconciler
+  Lambda in `terraform-aws-org-governance` handles the API interaction.
+- Does not suppress any other Vanta test. The `vanta-exempt:` tag is per-test;
+  encryption, public access, and versioning tests are unaffected.
+- Does not use `VantaNonProd` or `VantaNoAlert`. Those are whole-resource
+  scoped and remain available for genuinely non-prod ephemera.
+
+## Testing
+
+- `terraform plan` with an unknown slug should fail validation.
+- `terraform plan` with a reason > 256 chars should fail validation.
+- `terraform plan` with invalid characters in reason should fail validation.
+- `terraform plan` with valid exemptions should show the tag on the bucket.
+- Replica bucket should always have the CRR exemption tag when
+  `replication_region` is set, regardless of `vanta_exemptions` input.
+
+## Version bump
+
+Minor version bump (0.5.0) -- new variable with a default, no breaking changes.

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Full documentation is available on
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.44.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0, < 7.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ No modules.
 | <a name="input_object_ownership"></a> [object\_ownership](#input\_object\_ownership) | Object ownership setting for the bucket | `string` | `"BucketOwnerPreferred"` | no |
 | <a name="input_replication_region"></a> [replication\_region](#input\_replication\_region) | AWS region for the replica bucket.<br/>When null, no replication resources are created. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply on S3 bucket | `map(string)` | `{}` | no |
+| <a name="input_vanta_exemptions"></a> [vanta\_exemptions](#input\_vanta\_exemptions) | Map of Vanta test slugs to exemption reasons. Each entry causes a<br/>tag `vanta-exempt:<slug> = <reason>` to be applied to the bucket.<br/>The reconciler Lambda in terraform-aws-org-governance reads these<br/>tags and calls the Vanta per-test deactivation API.<br/><br/>Keys must be known Vanta test slugs (validated at plan time).<br/>Values must conform to AWS tag value constraints (<=256 chars,<br/>allowed character set). | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -197,14 +197,14 @@ Full documentation is available on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0, < 7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0, < 7.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.44.0 |
 
 ## Modules
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,42 @@ Constraints:
 Allow the bucket to be destroyed even if it contains objects. Applies to
 both source and replica buckets.
 
+### Compliance
+
+#### `vanta_exemptions`
+
+- **Type:** `map(string)`
+- **Default:** `{}`
+
+Map of Vanta test slugs to exemption reasons. Each entry adds a tag
+`vanta-exempt:<slug> = <reason>` to the bucket. A reconciler Lambda in
+`terraform-aws-org-governance` reads these tags and calls the Vanta
+per-test deactivation API.
+
+Known test slugs:
+
+- `aws-s3-cross-region-replication-enabled`
+
+Reasons must be 1-256 characters, using only letters, digits, spaces,
+and `+ - = . _ : / @`.
+
+```hcl
+module "lambda_artifacts" {
+  source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
+  version = "0.5.0"
+
+  bucket_prefix = "my-lambda-artifacts"
+
+  vanta_exemptions = {
+    "aws-s3-cross-region-replication-enabled" = "Lambda artifact bucket - ephemeral build output, no DR value"
+  }
+}
+```
+
+Note: replica buckets are automatically exempt from the CRR test — the
+module hardcodes the exemption tag since testing a replica for replication
+is nonsensical.
+
 ### Metadata
 
 #### `tags`

--- a/locals.tf
+++ b/locals.tf
@@ -6,4 +6,13 @@ locals {
     created_by_module : local.module_name
     module_version = local.module_version
   }
+
+  known_vanta_test_slugs = [
+    "aws-s3-cross-region-replication-enabled",
+  ]
+
+  vanta_exempt_tags = {
+    for slug, reason in var.vanta_exemptions :
+    "vanta-exempt:${slug}" => reason
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ resource "aws_s3_bucket" "this" {
   tags = merge(
     local.default_module_tags,
     var.tags,
+    local.vanta_exempt_tags,
     {
       "module_version" : local.module_version
     }

--- a/replication.tf
+++ b/replication.tf
@@ -8,6 +8,7 @@ resource "aws_s3_bucket" "replica" {
   tags = merge(
     local.default_module_tags,
     var.tags,
+    local.vanta_exempt_tags,
     {
       "vanta-exempt:aws-s3-cross-region-replication-enabled" = "Replica destination bucket - CRR test applies to source not target"
     },

--- a/replication.tf
+++ b/replication.tf
@@ -8,6 +8,9 @@ resource "aws_s3_bucket" "replica" {
   tags = merge(
     local.default_module_tags,
     var.tags,
+    {
+      "vanta-exempt:aws-s3-cross-region-replication-enabled" = "Replica destination bucket - CRR test applies to source not target"
+    },
   )
 
   lifecycle {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5"
+  required_version = "~> 1.9"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/variables.tf
+++ b/variables.tf
@@ -79,6 +79,51 @@ variable "object_ownership" {
   }
 }
 
+variable "vanta_exemptions" {
+  description = <<-EOT
+    Map of Vanta test slugs to exemption reasons. Each entry causes a
+    tag `vanta-exempt:<slug> = <reason>` to be applied to the bucket.
+    The reconciler Lambda in terraform-aws-org-governance reads these
+    tags and calls the Vanta per-test deactivation API.
+
+    Keys must be known Vanta test slugs (validated at plan time).
+    Values must conform to AWS tag value constraints (<=256 chars,
+    allowed character set).
+  EOT
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      for slug, reason in var.vanta_exemptions :
+      contains(local.known_vanta_test_slugs, slug)
+    ])
+    error_message = <<-EOT
+      Unknown Vanta test slug. Known slugs:
+        - aws-s3-cross-region-replication-enabled
+    EOT
+  }
+
+  validation {
+    condition = alltrue([
+      for slug, reason in var.vanta_exemptions :
+      length(reason) > 0 && length(reason) <= 256
+    ])
+    error_message = "Exemption reason must be between 1 and 256 characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for slug, reason in var.vanta_exemptions :
+      can(regex("^[\\w\\s+=.,:/@-]*$", reason))
+    ])
+    error_message = <<-EOT
+      Exemption reason may only contain letters, digits, spaces,
+      and the characters + - = . _ : / @
+    EOT
+  }
+}
+
 variable "replication_region" {
   description = <<-EOT
     AWS region for the replica bucket.


### PR DESCRIPTION
## Summary

- Adds `vanta_exemptions` variable that stamps `vanta-exempt:<test-slug> = <reason>` tags on buckets
- Replica buckets are auto-exempt from `aws-s3-cross-region-replication-enabled` — testing a replica for CRR is nonsensical
- Tags are consumed by a reconciler Lambda in `terraform-aws-org-governance` that calls the Vanta per-test deactivation API (INF-1539)
- Includes validation for known slugs, reason length, and AWS tag character constraints

## Test plan

- [ ] `terraform validate` passes
- [ ] `terraform plan` with unknown slug fails validation
- [ ] `terraform plan` with valid exemption shows tag on bucket
- [ ] Replica bucket always has CRR exemption tag when `replication_region` is set
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)