### PR TITLE
fix: remove comma from vanta_exemptions tag validation regex

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -112,10 +112,14 @@ variable "vanta_exemptions" {
     error_message = "Exemption reason must be between 1 and 256 characters."
   }
 
+  # Allowed characters per AWS tag restrictions:
+  # "letters (a-z, A-Z), numbers (0-9), and spaces representable in UTF-8,
+  #  and the following characters: + - = . _ : / @"
+  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
   validation {
     condition = alltrue([
       for slug, reason in var.vanta_exemptions :
-      can(regex("^[\\w\\s+=.,:/@-]*$", reason))
+      can(regex("^[\\w\\s+=.:/@-]*$", reason))
     ])
     error_message = <<-EOT
       Exemption reason may only contain letters, digits, spaces,


### PR DESCRIPTION
## Summary

- Remove comma (`,`) from the `vanta_exemptions` regex character class — commas are not in the AWS-allowed tag character set (`[a-zA-Z0-9 +-=._:/@]`), so the validation was passing values that S3 rejects at apply time.
- Add a comment citing the [AWS tag restrictions docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions) as the source of truth for allowed characters.

Closes #24

## Test plan

- [ ] Verify `terraform validate` passes
- [ ] Confirm a reason containing a comma now fails at plan time
- [ ] Confirm a reason with only valid characters still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)