### PR TITLE
feat: require replication or Vanta exemption for every bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,24 +36,34 @@ replication — all with a single `module` block.
 
 ## Quick Start
 
+Every bucket must either enable cross-region replication (`replication_region`)
+or carry an explicit Vanta exemption. This ensures compliance with the
+`aws-s3-cross-region-replication-enabled` Vanta test.
+
 ```hcl
 module "foo" {
     source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
     version = "0.5.1"
 
-    bucket_name = "foo-bucket"
+    bucket_name        = "foo-bucket"
+    replication_region = "us-east-1"
 }
 ```
 
-### With Cross-Region Replication
+### Without Replication (Vanta Exemption)
+
+If replication is unnecessary for a bucket, provide an exemption reason:
 
 ```hcl
-module "replicated" {
+module "artifacts" {
     source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
     version = "0.5.1"
 
-    bucket_name        = "my-replicated-bucket"
-    replication_region = "us-east-1"
+    bucket_prefix = "build-artifacts"
+
+    vanta_exemptions = {
+        "aws-s3-cross-region-replication-enabled" = "Ephemeral build artifacts - no DR value"
+    }
 }
 ```
 
@@ -86,6 +96,10 @@ module "cloudfront_logs" {
     acl              = "private"
     object_ownership = "BucketOwnerPreferred"
     bucket_policy    = data.aws_iam_policy_document.cloudfront_logs.json
+
+    vanta_exemptions = {
+        "aws-s3-cross-region-replication-enabled" = "Log bucket - replicated via log aggregation pipeline"
+    }
 }
 
 # Use in CloudFront distribution
@@ -112,6 +126,10 @@ module "s3_access_logs" {
     enable_acl       = true
     acl              = "log-delivery-write"
     object_ownership = "BucketOwnerPreferred"
+
+    vanta_exemptions = {
+        "aws-s3-cross-region-replication-enabled" = "Log bucket - replicated via log aggregation pipeline"
+    }
 }
 
 # Use in another S3 bucket

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,10 @@ AWS region for the cross-region replica bucket. When set, creates a full
 replica with identical security settings. Versioning is automatically
 enabled on the source bucket (required by S3 for replication).
 
+**Required unless exempted:** Either `replication_region` must be set or
+a Vanta exemption for `aws-s3-cross-region-replication-enabled` must be
+provided via `vanta_exemptions`. This is enforced at plan time.
+
 Constraints:
 
 - If using `bucket_name`: must be <= 55 characters (63 max minus 8 for
@@ -124,7 +128,7 @@ module "lambda_artifacts" {
   bucket_prefix = "my-lambda-artifacts"
 
   vanta_exemptions = {
-    "aws-s3-cross-region-replication-enabled" = "Lambda artifact bucket - ephemeral build output, no DR value"
+    "aws-s3-cross-region-replication-enabled" = "Lambda artifact bucket - ephemeral build output. No DR value"
   }
 }
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,7 +7,8 @@ module "data" {
   source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
   version = "0.5.1"
 
-  bucket_name = "my-app-data"
+  bucket_name        = "my-app-data"
+  replication_region = "us-east-1"
 }
 ```
 
@@ -18,8 +19,9 @@ module "versioned" {
   source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
   version = "0.5.1"
 
-  bucket_name       = "my-versioned-data"
-  enable_versioning = true
+  bucket_name        = "my-versioned-data"
+  enable_versioning  = true
+  replication_region = "us-east-1"
 }
 ```
 
@@ -63,6 +65,10 @@ module "cloudfront_logs" {
   acl              = "private"
   object_ownership = "BucketOwnerPreferred"
   bucket_policy    = data.aws_iam_policy_document.cloudfront_logs.json
+
+  vanta_exemptions = {
+    "aws-s3-cross-region-replication-enabled" = "Log bucket - replicated via log aggregation pipeline"
+  }
 }
 ```
 
@@ -79,6 +85,10 @@ module "s3_logs" {
   enable_acl       = true
   acl              = "log-delivery-write"
   object_ownership = "BucketOwnerPreferred"
+
+  vanta_exemptions = {
+    "aws-s3-cross-region-replication-enabled" = "Log bucket - replicated via log aggregation pipeline"
+  }
 }
 ```
 
@@ -102,8 +112,9 @@ module "bucket" {
   source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
   version = "0.5.1"
 
-  bucket_prefix = "shared-data"
-  bucket_policy = data.aws_iam_policy_document.custom.json
+  bucket_prefix      = "shared-data"
+  bucket_policy      = data.aws_iam_policy_document.custom.json
+  replication_region = "us-east-1"
 }
 ```
 
@@ -118,5 +129,9 @@ module "temp" {
 
   bucket_prefix = "temp-data"
   force_destroy = true
+
+  vanta_exemptions = {
+    "aws-s3-cross-region-replication-enabled" = "Temporary bucket - destroyed after use"
+  }
 }
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,12 +10,16 @@
 
 ### Basic Bucket
 
+Every bucket must either enable cross-region replication or carry an
+explicit Vanta exemption (see [Configuration](configuration.md#vanta_exemptions)).
+
 ```hcl
 module "bucket" {
   source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
   version = "0.5.1"
 
-  bucket_name = "my-app-data"
+  bucket_name        = "my-app-data"
+  replication_region = "us-east-1"
 }
 ```
 
@@ -24,7 +28,8 @@ This creates an S3 bucket with:
 - AES256 encryption at rest
 - SSL-only access policy
 - Public access fully blocked
-- No versioning (opt-in via `enable_versioning = true`)
+- Cross-region replica in `us-east-1`
+- No versioning on user side (auto-enabled for replication)
 
 ### Bucket with Cross-Region Replication
 
@@ -57,6 +62,10 @@ module "bucket" {
 
   bucket_prefix = "my-app"
   force_destroy = true
+
+  vanta_exemptions = {
+    "aws-s3-cross-region-replication-enabled" = "Ephemeral bucket - no DR value"
+  }
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,24 +21,32 @@ and blocks public access by default.
 
 ## Quick Start
 
+Every bucket must either enable cross-region replication or carry an
+explicit Vanta exemption for the `aws-s3-cross-region-replication-enabled`
+test.
+
 ```hcl
 module "bucket" {
   source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
   version = "0.5.1"
 
-  bucket_name = "my-secure-bucket"
+  bucket_name        = "my-secure-bucket"
+  replication_region = "us-east-1"
 }
 ```
 
-### With Cross-Region Replication
+### Without Replication (Vanta Exemption)
 
 ```hcl
 module "bucket" {
   source  = "registry.infrahouse.com/infrahouse/s3-bucket/aws"
   version = "0.5.1"
 
-  bucket_name        = "my-replicated-bucket"
-  replication_region = "us-east-1"
+  bucket_prefix = "build-artifacts"
+
+  vanta_exemptions = {
+    "aws-s3-cross-region-replication-enabled" = "Ephemeral build artifacts - no DR value"
+  }
 }
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,6 +17,29 @@ the replica gets `-replica` appended to the prefix, plus AWS adds a
 
 **Solution:** Shorten the prefix to 29 characters or fewer.
 
+### "S3 cross-region replication is required"
+
+**Problem:** Neither `replication_region` nor a Vanta exemption for
+`aws-s3-cross-region-replication-enabled` was provided.
+
+**Solution:** Either enable replication or declare an exemption:
+
+```hcl
+# Option 1: enable replication
+module "bucket" {
+  # ...
+  replication_region = "us-east-1"
+}
+
+# Option 2: exempt from the Vanta test
+module "bucket" {
+  # ...
+  vanta_exemptions = {
+    "aws-s3-cross-region-replication-enabled" = "Reason replication is unnecessary"
+  }
+}
+```
+
 ### "ACLs cannot be enabled when object_ownership is BucketOwnerEnforced"
 
 **Problem:** You set `enable_acl = true` with the default or explicit
@@ -32,6 +55,10 @@ module "logs" {
   bucket_name      = "my-logs"
   enable_acl       = true
   object_ownership = "BucketOwnerPreferred"
+
+  vanta_exemptions = {
+    "aws-s3-cross-region-replication-enabled" = "Log bucket - replicated via log aggregation pipeline"
+  }
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,21 @@ resource "aws_s3_bucket" "this" {
       "module_version" : local.module_version
     }
   )
+
+  lifecycle {
+    precondition {
+      condition = (
+        var.replication_region != null
+        ? true
+        : contains(keys(var.vanta_exemptions), "aws-s3-cross-region-replication-enabled")
+      )
+      error_message = <<-EOT
+        S3 cross-region replication is required. Either set replication_region
+        or add a Vanta exemption for "aws-s3-cross-region-replication-enabled"
+        in the vanta_exemptions variable.
+      EOT
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "public_access" {


### PR DESCRIPTION
## Summary

- Adds a `lifecycle.precondition` on `aws_s3_bucket.this` that fails `terraform plan` unless `replication_region` is set or `vanta_exemptions` includes the `aws-s3-cross-region-replication-enabled` slug
- Updates all documentation examples (README, docs/) to comply with the new requirement
- Adds a troubleshooting entry for the new error message

## Test plan

- [ ] `terraform plan` fails when neither `replication_region` nor the exemption is set
- [ ] `terraform plan` succeeds when `replication_region` is set
- [ ] `terraform plan` succeeds when `vanta_exemptions` includes the CRR slug
- [ ] Existing tests updated to pass the new precondition

🤖 Generated with [Claude Code](https://claude.com/claude-code)