### PR TITLE
feat: add S3 Object Lock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ No modules.
 | [aws_s3_bucket.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_object_lock_configuration.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration) | resource |
+| [aws_s3_bucket_object_lock_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration) | resource |
 | [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
@@ -266,6 +268,8 @@ No modules.
 | <a name="input_enable_acl"></a> [enable\_acl](#input\_enable\_acl) | Enable ACL for the S3 bucket (required for CloudFront logging) | `bool` | `false` | no |
 | <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | Enable versioning for the S3 bucket | `bool` | `false` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Allow bucket to be destroyed even if it contains objects | `bool` | `false` | no |
+| <a name="input_object_lock_default_retention"></a> [object\_lock\_default\_retention](#input\_object\_lock\_default\_retention) | Default retention applied to every new object version. When null, the<br/>Object Lock capability is enabled but no retention is enforced<br/>(capability-only). Requires object\_lock\_enabled = true.<br/>Specify exactly one of days or years. | <pre>object({<br/>    mode  = string # GOVERNANCE | COMPLIANCE<br/>    days  = optional(number)<br/>    years = optional(number)<br/>  })</pre> | `null` | no |
+| <a name="input_object_lock_enabled"></a> [object\_lock\_enabled](#input\_object\_lock\_enabled) | Enable S3 Object Lock (WORM) on the bucket. Create-time only and<br/>permanent - it cannot be disabled later, and it forces versioning on.<br/>Enabling the capability alone does NOT make objects immutable; set<br/>object\_lock\_default\_retention to enforce retention. | `bool` | `false` | no |
 | <a name="input_object_ownership"></a> [object\_ownership](#input\_object\_ownership) | Object ownership setting for the bucket | `string` | `"BucketOwnerPreferred"` | no |
 | <a name="input_replication_region"></a> [replication\_region](#input\_replication\_region) | AWS region for the replica bucket.<br/>When null, no replication resources are created. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply on S3 bucket | `map(string)` | `{}` | no |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,8 @@ Object ownership setting. Options:
 - **Type:** `bool`
 - **Default:** `false`
 
-Enable object versioning. Required when using `replication_region`.
+Enable object versioning. Automatically forced on when using
+`replication_region` or `object_lock_enabled` (both require versioning).
 
 #### `replication_region`
 
@@ -90,6 +91,45 @@ Constraints:
   `-replica` suffix)
 - If using `bucket_prefix`: must be <= 29 characters (63 max minus 26-char
   AWS suffix minus 8 for `-replica`)
+
+#### `object_lock_enabled`
+
+- **Type:** `bool`
+- **Default:** `false`
+
+Enable S3 Object Lock (WORM) on the bucket. This is a **create-time only**
+capability and **cannot be disabled** later; it also forces versioning on.
+When replication is configured, the replica bucket gets Object Lock enabled
+too, which is what allows a locked source bucket to replicate at all (AWS
+rejects replication when the source is locked but the destination is not).
+
+Enabling the capability alone does **not** make objects immutable - it only
+permits retention. Set `object_lock_default_retention` to actually enforce
+WORM. A `check` block warns when the capability is on without retention.
+
+#### `object_lock_default_retention`
+
+- **Type:** `object({ mode = string, days = optional(number), years = optional(number) })`
+- **Default:** `null`
+
+Default retention applied to every new object version on both the source and
+the replica. Requires `object_lock_enabled = true`.
+
+- `mode` - `GOVERNANCE` (privileged users can bypass with
+  `s3:BypassGovernanceRetention`) or `COMPLIANCE` (no one can delete or
+  shorten until retention expires, not even the root account).
+- Specify **exactly one** of `days` or `years`.
+
+```hcl
+object_lock_enabled = true
+object_lock_default_retention = {
+  mode = "GOVERNANCE"
+  days = 30
+}
+```
+
+When `null`, the bucket is capability-only: Object Lock is enabled but no
+retention is enforced.
 
 ### Lifecycle
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 resource "aws_s3_bucket" "this" {
-  bucket        = var.bucket_name
-  bucket_prefix = var.bucket_prefix
-  force_destroy = var.force_destroy
+  bucket              = var.bucket_name
+  bucket_prefix       = var.bucket_prefix
+  force_destroy       = var.force_destroy
+  object_lock_enabled = var.object_lock_enabled
   tags = merge(
     local.default_module_tags,
     var.tags,
@@ -23,6 +24,10 @@ resource "aws_s3_bucket" "this" {
         or add a Vanta exemption for "aws-s3-cross-region-replication-enabled"
         in the vanta_exemptions variable.
       EOT
+    }
+    precondition {
+      condition     = var.object_lock_default_retention == null ? true : var.object_lock_enabled
+      error_message = "object_lock_default_retention requires object_lock_enabled = true."
     }
   }
 }

--- a/object_lock.tf
+++ b/object_lock.tf
@@ -1,0 +1,26 @@
+resource "aws_s3_bucket_object_lock_configuration" "this" {
+  count  = var.object_lock_enabled && var.object_lock_default_retention != null ? 1 : 0
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    default_retention {
+      mode  = var.object_lock_default_retention.mode
+      days  = var.object_lock_default_retention.days
+      years = var.object_lock_default_retention.years
+    }
+  }
+}
+
+# Soft nudge: Object Lock capability without default retention is non-enforcing
+# (WORM is not actually applied). Warn rather than fail - capability-only is a
+# legitimate state (e.g. retention driven solely by per-object settings).
+check "object_lock_non_enforcing" {
+  assert {
+    condition     = !var.object_lock_enabled || var.object_lock_default_retention != null
+    error_message = <<-EOT
+      object_lock_enabled is true but object_lock_default_retention is null:
+      the Object Lock capability is on but no retention is enforced, so objects
+      are NOT immutable. Set object_lock_default_retention to enforce WORM.
+    EOT
+  }
+}

--- a/replication.tf
+++ b/replication.tf
@@ -1,9 +1,10 @@
 resource "aws_s3_bucket" "replica" {
-  count         = var.replication_region != null ? 1 : 0
-  bucket        = var.bucket_name != null ? "${var.bucket_name}-replica" : null
-  bucket_prefix = var.bucket_prefix != null ? "${var.bucket_prefix}-replica" : null
-  force_destroy = var.force_destroy
-  region        = var.replication_region
+  count               = var.replication_region != null ? 1 : 0
+  bucket              = var.bucket_name != null ? "${var.bucket_name}-replica" : null
+  bucket_prefix       = var.bucket_prefix != null ? "${var.bucket_prefix}-replica" : null
+  force_destroy       = var.force_destroy
+  region              = var.replication_region
+  object_lock_enabled = var.object_lock_enabled
 
   tags = merge(
     local.default_module_tags,
@@ -64,6 +65,23 @@ resource "aws_s3_bucket_versioning" "replica" {
   region = var.replication_region
   versioning_configuration {
     status = "Enabled"
+  }
+}
+
+# Mirror the source default retention onto the replica so the DR copy is a true
+# WORM copy. The replica shares object_lock_enabled with the source, so the AWS
+# "destination must also be locked" replication rule holds by construction.
+resource "aws_s3_bucket_object_lock_configuration" "replica" {
+  count  = var.replication_region != null && var.object_lock_enabled && var.object_lock_default_retention != null ? 1 : 0
+  bucket = aws_s3_bucket.replica[0].id
+  region = var.replication_region
+
+  rule {
+    default_retention {
+      mode  = var.object_lock_default_retention.mode
+      days  = var.object_lock_default_retention.days
+      years = var.object_lock_default_retention.years
+    }
   }
 }
 
@@ -138,6 +156,9 @@ data "aws_iam_policy_document" "replication_policy" {
       "s3:GetObjectVersionForReplication",
       "s3:GetObjectVersionAcl",
       "s3:GetObjectVersionTagging",
+      # Required to replicate Object Lock metadata; harmless when lock is off.
+      "s3:GetObjectRetention",
+      "s3:GetObjectLegalHold",
     ]
     resources = [
       "${aws_s3_bucket.this.arn}/*",

--- a/test_data/test_object_lock/.gitignore
+++ b/test_data/test_object_lock/.gitignore
@@ -1,0 +1,2 @@
+terraform.tf
+.terraform

--- a/test_data/test_object_lock/datasources.tf
+++ b/test_data/test_object_lock/datasources.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/test_data/test_object_lock/main.tf
+++ b/test_data/test_object_lock/main.tf
@@ -1,0 +1,27 @@
+module "bucket" {
+  source        = "../../"
+  bucket_prefix = "lock"
+  force_destroy = true
+  bucket_policy = data.aws_iam_policy_document.bucket_policy.json
+
+  replication_region            = var.replication_region
+  object_lock_enabled           = true
+  object_lock_default_retention = var.object_lock_default_retention
+}
+
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "${module.bucket.bucket_arn}/*",
+    ]
+  }
+}

--- a/test_data/test_object_lock/outputs.tf
+++ b/test_data/test_object_lock/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_name" {
+  value = module.bucket.bucket_name
+}
+
+output "replica_bucket_name" {
+  value = module.bucket.replica_bucket_name
+}

--- a/test_data/test_object_lock/providers.tf
+++ b/test_data/test_object_lock/providers.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  dynamic "assume_role" {
+    for_each = var.role_arn != null ? [1] : []
+    content {
+      role_arn = var.role_arn
+    }
+  }
+  region = var.region
+  default_tags {
+    tags = {
+      "created_by" : "infrahouse/terraform-aws-s3-bucket" # GitHub repository that created a resource
+    }
+
+  }
+}

--- a/test_data/test_object_lock/variables.tf
+++ b/test_data/test_object_lock/variables.tf
@@ -1,0 +1,15 @@
+variable "role_arn" {
+  default = null
+}
+variable "region" {
+}
+variable "replication_region" {
+}
+variable "object_lock_default_retention" {
+  type = object({
+    mode  = string
+    days  = optional(number)
+    years = optional(number)
+  })
+  default = null
+}

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -114,3 +114,165 @@ def test_module(
             )
         assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
         LOG.info("KMS upload correctly denied")
+
+
+def _purge_object_lock_bucket(s3_client, bucket):
+    """
+    Delete every object version and delete marker in a bucket, bypassing
+    GOVERNANCE retention, so a force_destroy bucket can be torn down even when
+    locked objects remain.
+
+    :param s3_client: boto3 S3 client in the bucket's region.
+    :param bucket: Bucket name to purge.
+    """
+    paginator = s3_client.get_paginator("list_object_versions")
+    for page in paginator.paginate(Bucket=bucket):
+        for marker in page.get("Versions", []) + page.get("DeleteMarkers", []):
+            s3_client.delete_object(
+                Bucket=bucket,
+                Key=marker["Key"],
+                VersionId=marker["VersionId"],
+                BypassGovernanceRetention=True,
+            )
+
+
+def _wait_for_replication(s3_replica, replica_bucket, test_key):
+    """Poll the replica bucket until ``test_key`` appears (or time out)."""
+    with timeout(300):
+        while True:
+            time.sleep(10)
+            try:
+                s3_replica.get_object(Bucket=replica_bucket, Key=test_key)
+                LOG.info("Object %s replicated to %s", test_key, replica_bucket)
+                return
+            except s3_replica.exceptions.NoSuchKey:
+                LOG.info("Object not yet replicated, retrying...")
+
+
+@pytest.mark.parametrize("aws_provider_version", ["~> 6.0"], ids=["aws-6"])
+@pytest.mark.parametrize(
+    "retention",
+    [
+        None,
+        {"mode": "GOVERNANCE", "days": 1},
+    ],
+    ids=["capability-only", "full-worm"],
+)
+def test_object_lock(
+    boto3_session,
+    test_role_arn,
+    keep_after,
+    aws_region,
+    aws_provider_version,
+    retention,
+):
+    # An HCL object literal accepts JSON syntax (colon-separated keys), so a
+    # plain json.dumps of the dict is a valid tfvars value.
+    enforced = retention is not None
+    terraform_dir = osp.join(TERRAFORM_ROOT_DIR, "test_object_lock")
+    state_files = [
+        osp.join(terraform_dir, ".terraform"),
+        osp.join(terraform_dir, ".terraform.lock.hcl"),
+    ]
+
+    for state_file in state_files:
+        try:
+            if osp.isdir(state_file):
+                rmtree(state_file)
+            elif osp.isfile(state_file):
+                remove(state_file)
+        except FileNotFoundError:
+            pass
+
+    with open(osp.join(terraform_dir, "terraform.tf"), "w") as fp:
+        fp.write(dedent(f"""
+                terraform {{
+                  required_providers {{
+                    aws = {{
+                      source  = "hashicorp/aws"
+                      version = "{aws_provider_version}"
+                    }}
+                  }}
+                }}
+                """))
+
+    # Cross-region replication requires a destination region different from the
+    # source, so derive it from aws_region instead of hardcoding.
+    replica_region = "us-east-1" if aws_region == "us-west-1" else "us-west-1"
+
+    with open(osp.join(terraform_dir, "terraform.tfvars"), "w") as fp:
+        fp.write(dedent(f"""
+                region             = "{aws_region}"
+                replication_region = "{replica_region}"
+                """))
+        if test_role_arn:
+            fp.write(dedent(f"""
+                    role_arn      = "{test_role_arn}"
+                    """))
+        if retention is not None:
+            fp.write(f"object_lock_default_retention = {json.dumps(retention)}\n")
+
+    with terraform_apply(
+        terraform_dir,
+        destroy_after=not keep_after,
+        json_output=True,
+    ) as tf_output:
+        LOG.info(json.dumps(tf_output, indent=4))
+
+        source_bucket = tf_output["bucket_name"]["value"]
+        replica_bucket = tf_output["replica_bucket_name"]["value"]
+
+        assert replica_bucket is not None
+        assert "-replica" in replica_bucket
+
+        s3_source = boto3_session.client("s3", region_name=aws_region)
+        s3_replica = boto3_session.client("s3", region_name=replica_region)
+
+        # Both source and replica must have the Object Lock capability enabled.
+        for client, bucket in (
+            (s3_source, source_bucket),
+            (s3_replica, replica_bucket),
+        ):
+            config = client.get_object_lock_configuration(Bucket=bucket)
+            assert config["ObjectLockConfiguration"]["ObjectLockEnabled"] == "Enabled"
+            rule = config["ObjectLockConfiguration"].get("Rule")
+            if enforced:
+                retention = rule["DefaultRetention"]
+                assert retention["Mode"] == "GOVERNANCE"
+                assert retention["Days"] == 1
+            else:
+                # Capability-only: no default retention rule is configured.
+                assert rule is None
+
+        # Replication still works with Object Lock enabled.
+        test_key = "test-object-lock-replication.txt"
+        s3_source.put_object(Bucket=source_bucket, Key=test_key, Body=b"locked content")
+        _wait_for_replication(s3_replica, replica_bucket, test_key)
+
+        if enforced:
+            # A version under GOVERNANCE retention cannot be deleted without bypass.
+            version_id = s3_source.head_object(Bucket=source_bucket, Key=test_key)[
+                "VersionId"
+            ]
+            with pytest.raises(botocore.exceptions.ClientError) as exc_info:
+                s3_source.delete_object(
+                    Bucket=source_bucket,
+                    Key=test_key,
+                    VersionId=version_id,
+                )
+            assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+            LOG.info("Locked version delete correctly denied without bypass")
+
+            # With BypassGovernanceRetention the same delete succeeds.
+            s3_source.delete_object(
+                Bucket=source_bucket,
+                Key=test_key,
+                VersionId=version_id,
+                BypassGovernanceRetention=True,
+            )
+            LOG.info("Locked version deleted with governance bypass")
+
+        if not keep_after:
+            # Locked object versions block force_destroy; purge them first.
+            _purge_object_lock_bucket(s3_source, source_bucket)
+            _purge_object_lock_bucket(s3_replica, replica_bucket)

--- a/variables.tf
+++ b/variables.tf
@@ -136,3 +136,44 @@ variable "replication_region" {
   type        = string
   default     = null
 }
+
+variable "object_lock_enabled" {
+  description = <<-EOT
+    Enable S3 Object Lock (WORM) on the bucket. Create-time only and
+    permanent - it cannot be disabled later, and it forces versioning on.
+    Enabling the capability alone does NOT make objects immutable; set
+    object_lock_default_retention to enforce retention.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "object_lock_default_retention" {
+  description = <<-EOT
+    Default retention applied to every new object version. When null, the
+    Object Lock capability is enabled but no retention is enforced
+    (capability-only). Requires object_lock_enabled = true.
+    Specify exactly one of days or years.
+  EOT
+  type = object({
+    mode  = string # GOVERNANCE | COMPLIANCE
+    days  = optional(number)
+    years = optional(number)
+  })
+  default = null
+
+  validation {
+    condition = var.object_lock_default_retention == null ? true : (
+      contains(["GOVERNANCE", "COMPLIANCE"], var.object_lock_default_retention.mode)
+    )
+    error_message = "object_lock_default_retention.mode must be GOVERNANCE or COMPLIANCE."
+  }
+
+  validation {
+    condition = var.object_lock_default_retention == null ? true : (
+      (var.object_lock_default_retention.days != null) !=
+      (var.object_lock_default_retention.years != null)
+    )
+    error_message = "Specify exactly one of object_lock_default_retention.days or .years."
+  }
+}

--- a/versioning.tf
+++ b/versioning.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket_versioning" "enabled" {
-  count  = var.enable_versioning || var.replication_region != null ? 1 : 0
+  count  = var.enable_versioning || var.replication_region != null || var.object_lock_enabled ? 1 : 0
   bucket = aws_s3_bucket.this.id
   versioning_configuration {
     status = "Enabled"


### PR DESCRIPTION
## Why

Two object-lock buckets in `aws-control-sandbox` (`ml-datasets`, `friday-logs`) are flagged by the Vanta cross-region-replication test but cannot adopt this module today: the module's replica bucket has no Object Lock, and AWS rejects `PutBucketReplication` when the **source** has Object Lock enabled but the **destination** does not. Adding Object Lock support here lets those buckets migrate via `moved` blocks non-destructively and fixes the capability for every consumer.

## What

- **`object_lock_enabled`** (bool, default `false`) — create-time WORM capability on source + replica. Forces versioning on.
- **`object_lock_default_retention`** (object, default `null`) — optional default retention (`mode` = GOVERNANCE/COMPLIANCE, exactly one of `days`/`years`). When set, enforces real WORM; mirrored to the replica for a true DR copy.
- A `precondition` requires the capability for retention; a `check` block warns when the capability is on **without** retention (non-enforcing WORM — the "half-configured trap").
- Replication IAM policy gains `s3:GetObjectRetention` and `s3:GetObjectLegalHold`.

## Backward compatibility

All new inputs default off → no behavior change for existing callers, and `object_lock_enabled = false` matches existing module-created buckets, so **no ForceNew replacement** on upgrade. Additive → minor bump (0.7.0 at release time).

## Tests

New `test_object_lock` parametrized over `capability-only` and `full-worm`:
- asserts Object Lock enabled on source + replica,
- retention rule present only when enforced,
- replication still works under lock,
- GOVERNANCE delete denied without bypass / succeeds with bypass,
- purges locked versions before teardown so `force_destroy` works.

The existing backward-compat replication test is unchanged.

## Notes

- CHANGELOG + version bump to 0.7.0 are intentionally left for the release flow (`make release-minor`).
- COMPLIANCE mode is not exercised in tests because COMPLIANCE-locked objects can't be deleted until retention expires (would block teardown); tests use GOVERNANCE (bypassable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)