### PR TITLE
feat: add bucket_name_with_policy output

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ No modules.
 | <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | The ARN of the S3 bucket |
 | <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | The bucket domain name (legacy global endpoint format: bucket-name.s3.amazonaws.com) |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | The name of the S3 bucket |
+| <a name="output_bucket_name_with_policy"></a> [bucket\_name\_with\_policy](#output\_bucket\_name\_with\_policy) | The bucket name, sourced from the bucket policy resource. Reference this<br/>(instead of bucket\_name) when you need the bucket policy to be attached<br/>before using the bucket - consuming it creates an implicit dependency on<br/>aws\_s3\_bucket\_policy.this. Avoids first-apply races such as enabling ALB<br/>access logging before the log-delivery policy exists. |
 | <a name="output_bucket_regional_domain_name"></a> [bucket\_regional\_domain\_name](#output\_bucket\_regional\_domain\_name) | The bucket regional domain name (format: bucket-name.s3.region.amazonaws.com) |
 | <a name="output_replica_bucket_arn"></a> [replica\_bucket\_arn](#output\_replica\_bucket\_arn) | ARN of the replica bucket,<br/>or null if replication disabled. |
 | <a name="output_replica_bucket_name"></a> [replica\_bucket\_name](#output\_replica\_bucket\_name) | Name of the replica bucket,<br/>or null if replication disabled. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,6 +76,7 @@ After apply, the module exposes:
 | Output | Description |
 |--------|-------------|
 | `bucket_name` | The bucket name |
+| `bucket_name_with_policy` | Bucket name; depends on the policy being attached (avoids first-apply races) |
 | `bucket_arn` | The bucket ARN |
 | `bucket_domain_name` | Legacy global endpoint |
 | `bucket_regional_domain_name` | Regional endpoint |

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,17 @@ output "bucket_name" {
   value       = aws_s3_bucket.this.bucket
 }
 
+output "bucket_name_with_policy" {
+  description = <<-EOT
+    The bucket name, sourced from the bucket policy resource. Reference this
+    (instead of bucket_name) when you need the bucket policy to be attached
+    before using the bucket - consuming it creates an implicit dependency on
+    aws_s3_bucket_policy.this. Avoids first-apply races such as enabling ALB
+    access logging before the log-delivery policy exists.
+  EOT
+  value       = aws_s3_bucket_policy.this.id # == the bucket name
+}
+
 output "bucket_arn" {
   description = "The ARN of the S3 bucket"
   value       = aws_s3_bucket.this.arn

--- a/test_data/test_module/outputs.tf
+++ b/test_data/test_module/outputs.tf
@@ -2,6 +2,10 @@ output "bucket_name" {
   value = module.bucket.bucket_name
 }
 
+output "bucket_name_with_policy" {
+  value = module.bucket.bucket_name_with_policy
+}
+
 output "replica_bucket_name" {
   value = module.bucket.replica_bucket_name
 }

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -74,6 +74,10 @@ def test_module(
         assert replica_bucket is not None
         assert "-replica" in replica_bucket
 
+        # bucket_name_with_policy is sourced from the policy resource but must
+        # be a drop-in equivalent of bucket_name for callers.
+        assert tf_output["bucket_name_with_policy"]["value"] == source_bucket
+
         s3_source = boto3_session.client("s3", region_name=aws_region)
         s3_replica = boto3_session.client("s3", region_name="us-west-1")
 


### PR DESCRIPTION
Closes #29

## Problem

The module's `bucket_name` output (`aws_s3_bucket.this.bucket`) depends only on the **bucket**, not on `aws_s3_bucket_policy.this`. Consumers that need the policy attached *before* using the bucket can't express that through outputs, forcing a coarse `depends_on = [module.<this>]`.

The motivating race (infrahouse/terraform-aws-website-pod#122): an ALB enables access logging referencing `module.access_log.bucket_name`. Because that output carries no policy dependency, Terraform's graph lets the ALB's `ModifyLoadBalancerAttributes` (which triggers ELB's synchronous test `PutObject`) run **before** the bucket policy is attached — first apply fails with `InvalidConfigurationRequest: Access Denied for bucket`, second apply succeeds.

## Change

Add `bucket_name_with_policy`, sourced from `aws_s3_bucket_policy.this.id` (which **equals** the bucket name). Referencing it creates an implicit dependency edge on the policy being attached, while remaining drop-in compatible with `bucket_name`.

- Purely additive, non-breaking — `bucket_name` is unchanged.
- Documented in the README outputs table (auto-generated) and `docs/getting-started.md`.
- Test asserts the new output equals `bucket_name` (drop-in compatibility).

Once released, `website-pod` can switch its ALB `access_logs.bucket` to this output and drop the coarse `depends_on`, fixing #122 cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)